### PR TITLE
Allow different parameters per real host in a virtual host definition

### DIFF
--- a/templates/ldirectord.virtual.cf.erb
+++ b/templates/ldirectord.virtual.cf.erb
@@ -1,6 +1,10 @@
 virtual=<%= @virtual %>:<%= @port %>
-<% @real.each do |real| -%>
-    real=<%= real %>:<%= @port %> <%= @real_options %>
+<% @real.each do |ip,config|
+     config  = {} if !config
+     port    = config['port'] or @port
+     options = config['options'] or @real_options
+-%>
+    real=<%= ip %>:<%= port %> <%= options %>
 <% end -%>
 <% if @service -%>
     service=<%= @service %>

--- a/templates/ldirectord.virtual.cf.erb
+++ b/templates/ldirectord.virtual.cf.erb
@@ -1,8 +1,8 @@
 virtual=<%= @virtual %>:<%= @port %>
 <% @real.each do |ip,config|
      config  = {} if !config
-     port    = config['port'] or @port
-     options = config['options'] or @real_options
+     port    = config['port'] || @port
+     options = config['options'] || @real_options
 -%>
     real=<%= ip %>:<%= port %> <%= options %>
 <% end -%>


### PR DESCRIPTION
This PR permits either the existing syntax, or alternatively to override the default **port** and **real_options** per real IP, by setting **real** as a hash; for example:
```
real => {
  '10.0.0.1' => {'port' => '25', 'options' => 'gate 40'},
  '10.0.0.2' => {'port' => '28', 'options' => 'gate 10'}
},
```
If **real** is an array, the behaviour is as before.  Either 'port', 'options' or both can be specified in the nested hash - if either is not specified, the normal parameter values are used.

I needed this behaviour to enable different weightings per real server.