### PR TITLE
virtual_host: Make service optional, and add checkcommand parameter

### DIFF
--- a/manifests/virtual_host.pp
+++ b/manifests/virtual_host.pp
@@ -4,7 +4,7 @@ define ldirectord::virtual_host(
   $real,
   $real_options,
   $port,
-  $service,
+  $service = undef,
   $protocol,
   $scheduler,
   $entrynumber = $name,

--- a/manifests/virtual_host.pp
+++ b/manifests/virtual_host.pp
@@ -10,6 +10,7 @@ define ldirectord::virtual_host(
   $entrynumber = $name,
   $checktype = undef,
   $checkport = undef,
+  $checkcommand = undef,
   $httpmethod = undef,
   $virtualhost = undef,
   $login = undef,

--- a/templates/ldirectord.virtual.cf.erb
+++ b/templates/ldirectord.virtual.cf.erb
@@ -27,6 +27,9 @@ virtual=<%= @virtual %>:<%= @port %>
 <% if @checkport -%>
     checkport=<%= @checkport %>
 <% end -%>
+<% if @checkcommand -%>
+    checkcommand=<%= @checkcommand %>
+<% end -%>
 <% if @httpmethod -%>
     httpmethod=<%= @httpmethod %>
 <% end -%>


### PR DESCRIPTION
service is only required by ldirectord for particular checktype (and even then, it defaults to 'none' if not specified).
checkcommand is necessary to use the external check type