### PR TITLE
Remove duplicate field checktype from virutal host

### DIFF
--- a/manifests/virtual_host.pp
+++ b/manifests/virtual_host.pp
@@ -24,7 +24,6 @@ define ldirectord::virtual_host(
   $database = undef,
   $request = undef,
   $receive = undef,
-  $checktype = undef,
   $netmask = undef,
   $persistent = undef,
 ) {


### PR DESCRIPTION
It's a duplicate and this fails if we try to upgrade puppet above 3.x